### PR TITLE
/bin/sh and /bin/bash are the same thing on Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SHELL := /bin/bash
+SHELL := /bin/sh
 
 SOURCE_FILES = $(wildcard *.odt)
 


### PR DESCRIPTION
Using /bin/sh keeps it portable